### PR TITLE
Fix bug in import statement

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -1,4 +1,4 @@
-from binary_tree_complete import Node
+from binary_tree import Node
 root = Node(10)
 toadd = [7, 4, 2, 9, 8, 15, 12, 17, 16, 18]
 #root = Node(4)


### PR DESCRIPTION
The import line `from binary_tree_complete import Node` caused an error and would not run the _testing.py_ file. Removing the `_complete` from `binary_tree_complete` fixes this error.